### PR TITLE
Bump runtime version to 23.08 and clean up appstream file

### DIFF
--- a/com.gitlab.coringao.cavestory-nx.appdata.xml
+++ b/com.gitlab.coringao.cavestory-nx.appdata.xml
@@ -16,11 +16,13 @@
     <p>Cave Story was originally created by Daisuke "Pixel" Amaya</p>
   </description>
   <screenshots>
-    <screenshot>
+    <screenshot type="default">
       <image type="source">https://gitlab.com/coringao/cavestory-nx/wikis/uploads/6e6f6e19a80f1143c925f6aad69f5bec/cavestory-nx.png</image>
+      <caption>The Title Screen for Cave Story (also known as Doukutsu Monogatari) NX 1.3.0</caption>
     </screenshot>
     <screenshot>
       <image type="source">https://gitlab.com/coringao/cavestory-nx/wikis/uploads/ce544c0a788a8f159b57797f9d8fd9e0/snapEscape.png</image>
+      <caption>A Picture of Cave Story (also known as Doukutsu Monogatari) paused on a screen in which there is a Mimiga (more aptly described as a cute bunny creature) fishing in a small lake, with a orange quilled fish nearby staring blankly at the screen.</caption>
     </screenshot>
   </screenshots>
   <releases>

--- a/com.gitlab.coringao.cavestory-nx.json
+++ b/com.gitlab.coringao.cavestory-nx.json
@@ -1,7 +1,7 @@
 {
   "app-id": "com.gitlab.coringao.cavestory-nx",
   "runtime": "org.freedesktop.Platform",
-  "runtime-version": "21.08",
+  "runtime-version": "23.08",
   "sdk": "org.freedesktop.Sdk",
   "command": "cavestory-nx",
   "finish-args": [


### PR DESCRIPTION
 These Syntax Updates are necessary to update the build, which then will allow the .json file on line 4 be updated to 23.8, which in my buildbot tests does work, as long as the necessary syntax is updated:

Line 19 was updated to type=default as requested in https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/#screenshots and by build error "com.gitlab.coringao.cavestory-nx:18: screenshot-default-missing"

Lines 21 and 25 were updated with descriptions, to fit the warning ""appstream-screenshot-missing-caption", feel free to improve them for the patch. If there are any concerns please let me know!